### PR TITLE
Attempt to avoid 504 Server Error Gateway Time-out

### DIFF
--- a/kubernetes/nginx/nginx.conf
+++ b/kubernetes/nginx/nginx.conf
@@ -44,17 +44,15 @@ server {
   # Serve Flask app (uwsgi)
   location / {
 
-    # app server (uwsgi)
-    proxy_pass http://127.0.0.1:5000;
     proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header Connection "upgrade";
+    proxy_set_header Host $host;
     proxy_http_version 1.1;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-
-    proxy_set_header Host $host;
-
-    # set X-Forwarded-Proto header
     proxy_set_header X-Forwarded-Proto $scheme;
 
+    # https://stackoverflow.com/questions/24453388/nginx-reverse-proxy-causing-504-gateway-timeout
+    proxy_set_header Connection "";
+
+    proxy_pass http://127.0.0.1:5000;
   }
 }


### PR DESCRIPTION
- Applied a tip from https://stackoverflow.com/questions/24453388/
nginx-reverse-proxy-causing-504-gateway-timeout