### PR TITLE
[DM-15359] Query API resources by filter_name

### DIFF
--- a/app/api_v1/code_changes.py
+++ b/app/api_v1/code_changes.py
@@ -11,6 +11,7 @@ from ..models import PackageModel as Package
 class CodeChanges(Resource):
     parser = reqparse.RequestParser()
     parser.add_argument('ci_dataset')
+    parser.add_argument('filter_name')
     parser.add_argument('period')
 
     def pairwise(self, iterable):
@@ -84,24 +85,45 @@ class CodeChanges(Resource):
         ---
         tags:
           - Apps
+        parameters:
+        - name: ci_dataset
+          in: url
+          type: string
+          description: >
+            Name of the data set used in this job, e.g: cfht, decam, hsc
+        - name: filter_name
+          in: url
+          type: string
+          description: >
+            Name of the filter associated to a given dataset, e.g 'r'
+            for cfht
+        - name: period
+          in: url
+          type: string
+          description: >
+             The period used to retrieve the data, e.g: "Last Month",
+             "Last 6 Months", "Last Year" or "All". By default retrieves
+             the last month of data.
         responses:
           200:
             description: List of packages successfully retrieved.
         """
-
         # join job and packages and get ci_id, packages name, git_commit
         # and git_url sorted by date
 
         queryset = Job.query.join(Package)
 
         args = self.parser.parse_args()
-        ci_dataset = args['ci_dataset']
 
+        ci_dataset = args['ci_dataset']
         if ci_dataset:
             queryset = queryset.filter(Job.ci_dataset == ci_dataset)
 
-        period = args['period']
+        filter_name = args['filter_name']
+        if filter_name:
+            queryset = queryset.filter(Job.meta['filter_name'] == filter_name)
 
+        period = args['period']
         if period:
             end = datetime.datetime.today()
 

--- a/app/api_v1/monitor.py
+++ b/app/api_v1/monitor.py
@@ -10,6 +10,7 @@ from ..models import MetricModel as Metric
 class Monitor(Resource):
     parser = reqparse.RequestParser()
     parser.add_argument('ci_dataset')
+    parser.add_argument('filter_name')
     parser.add_argument('metric')
     parser.add_argument('period')
 
@@ -25,6 +26,12 @@ class Monitor(Resource):
           type: string
           description: >
             Name of the data set used in this job, e.g: cfht, decam, hsc
+        - name: filter_name
+          in: url
+          type: string
+          description: >
+            Name of the filter associated to a given dataset, e.g 'r'
+            for cfht
         - name: period
           in: url
           type: string
@@ -44,6 +51,10 @@ class Monitor(Resource):
         ci_dataset = args['ci_dataset']
         if ci_dataset:
             queryset = queryset.filter(Job.ci_dataset == ci_dataset)
+
+        filter_name = args['filter_name']
+        if filter_name:
+            queryset = queryset.filter(Job.meta['filter_name'] == filter_name)
 
         metric = args['metric']
         if metric:


### PR DESCRIPTION
- The /monitor and /code_changes resources in the API can now be queried by `filter_name`, so that we can handle datasets with multiple filters. This PR is a workaround until we don't have a proper model for datasets in SQuaSH.
