### PR TITLE
Implement a celery task in the SQuaSH API to save time series data to InfluxDB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Project specific files
+kubernetes/deployment.yaml
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/app/api_v1/job.py
+++ b/app/api_v1/job.py
@@ -1,4 +1,5 @@
 import json
+import warnings
 
 from flask_restful import Resource, reqparse
 from flask_jwt import jwt_required
@@ -298,9 +299,9 @@ class Job(Resource):
             if metric:
                 m = MeasurementModel(job_id, metric.id, **measurement)
             else:
-                raise ApiError("Metric `{}` not found, it looks like "
-                               "the metrics definition is out of "
-                               "date.".format(metric_name), 400)
+                warnings.warn("Metric `{}` not found, it looks like "
+                              "the metrics definition is out of "
+                              "date.".format(metric_name))
 
             # Insert data blobs associated with this measurement
             blobs = self.data['blobs']

--- a/app/api_v1/job.py
+++ b/app/api_v1/job.py
@@ -6,6 +6,8 @@ from flask import current_app as app
 from flask import url_for
 
 from app.tasks.s3 import get_s3_uri, upload_object
+from app.tasks.influxdb import job_to_influxdb
+
 from app.error import ApiError
 
 from ..models import JobModel, MetricModel, MeasurementModel, PackageModel,\
@@ -154,9 +156,9 @@ class Job(Resource):
             app.logger.error(err.message)
             return {'message': err.message}, err.status_code
 
-        # async
+        # async task
         try:
-            self.upload_blobs()
+            self.upload_blobs_to_s3()
         except ApiError as err:
             app.logger.error(err.message)
             return {'message': err.message}, err.status_code
@@ -164,11 +166,19 @@ class Job(Resource):
         # async, the status of the job upload task can be accessed
         # from the /status resource
         try:
-            task = self.upload_job(job_id)
+            task = self.upload_job_to_s3(job_id)
         except ApiError as err:
             app.logger.error(err.message)
             return {'message': err.message}, err.status_code
 
+        # async task
+        try:
+            self.save_job_to_influxdb(job_id)
+        except ApiError as err:
+            app.logger.error(err.meassage)
+            return {'message': err.meassage}, err.status_code
+
+        # see DM-16391 for improving task status report
         message = "Request for creating Job `{}` received".format(job_id)
         return {'message': message, 'status': url_for('status',
                                                       task_id=task.id,
@@ -311,7 +321,7 @@ class Job(Resource):
                 raise ApiError("An error occurred inserting "
                                "measurements", 500)
 
-    def upload_job(self, job_id):
+    def upload_job_to_s3(self, job_id):
         """Upload job document to S3 and register the S3 URI
         location.
 
@@ -337,7 +347,7 @@ class Job(Resource):
 
         return task
 
-    def upload_blobs(self):
+    def upload_blobs_to_s3(self):
 
         blobs = self.data['blobs']
 
@@ -361,6 +371,26 @@ class Job(Resource):
                     except Exception:
                         raise ApiError("An error ocurred registering "
                                        "the S3 URI location.", 500)
+
+    def save_job_to_influxdb(self, job_id):
+        """Save verification job to InfluxDB
+
+        Parameters
+        ----------
+        job_id : `int`
+            id of the job object previously created.
+        """
+        data = self.data
+
+        date_created = None
+
+        job = JobModel.find_by_id(job_id)
+
+        if job:
+            date_created = job.date_created.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+        # async celery task
+        job_to_influxdb.delay(job_id, date_created, data)
 
 
 class JobList(Resource):

--- a/app/tasks/influxdb.py
+++ b/app/tasks/influxdb.py
@@ -1,0 +1,153 @@
+import os
+import math
+import requests
+from pytz import UTC
+from datetime import datetime
+from dateutil.parser import parse
+
+from .celery import celery
+
+INFLUXDB_API_URL = os.environ.get('INFLUXDB_API_URL')
+INFLUXDB_DATABASE = os.environ.get('INFLUXDB_DATABASE')
+
+
+def format_timestamp(date):
+    """ Format timestamp as required by the InfluxDB line protocol.
+
+        Parameters
+        ----------
+        date: `<str>`
+            Timestamp string
+
+        Returns
+        -------
+        timestamp: `<int>`
+            Timestamp in nanosecond-precision Unix time.
+            See https://docs.influxdata.com/influxdb/v1.6/write_protocols/
+    """
+
+    epoch = UTC.localize(datetime.utcfromtimestamp(0))
+
+    timestamp = int((parse(date) - epoch).total_seconds() * 1e9)
+
+    return timestamp
+
+
+def format_line(measurement, tags, fields, timestamp):
+    """ Format an InfluxDB line.
+
+        Parameters
+        ----------
+        measurement: `<str>`
+            Name of the InfluxDB measurement
+        tags: `<list>`
+            A list of valid InfluxDB tags
+        fields: `<list>`
+            A list of valid InfluxDB fields
+        timestamp: `int`
+            A timestamp as returned by `format_timestamp()`
+
+        Returns
+        -------
+        line: `<str>`
+            An InfluxDB line as defined by the line protocol in
+            https://docs.influxdata.com/influxdb/v1.6/write_protocols/
+    """
+    line = "{},{} {} {}".format(measurement, ",".join(tags), ",".join(fields),
+                                timestamp)
+    return line
+
+
+def send_to_influxdb(influxdb_line):
+    """ Send a line to an InfluxDB database. It assumes the database already
+        exists.
+
+        Parameters
+        ----------
+        influxdb_line: `<str>`
+            An InfluxDB line as defined by the line protocol in
+            https://docs.influxdata.com/influxdb/v1.6/write_protocols/
+
+        status_code: `<int>`
+            Status code from the InfluxDB HTTP API.
+    """
+
+    params = {'db': INFLUXDB_DATABASE}
+    r = requests.post(url=INFLUXDB_API_URL + "/write", params=params,
+                      data=influxdb_line)
+
+    return r.status_code, r.text
+
+
+@celery.task(bind=True)
+def job_to_influxdb(self, job_id, date_created, data):
+    """ Unpack a SQuaSH job and send to InfluxDB
+
+        Parameters
+        ----------
+        data: `<dict>`
+            A dictionary containing the job data
+
+        Returns
+        -------
+        status_code: `<int>`
+             204:
+               The request was processed successfully
+             400:
+               Malformed syntax or bad query
+
+        Note
+        ----
+        A lsst.verify measurement and an InfluxDB measurement are different
+        things. See e.g.:
+        https://docs.influxdata.com/influxdb/v1.6/concepts/key_concepts/
+    """
+
+    # The datamodel for a SQuaSH job in InfluxDB maps each verification package
+    # to an InfluxDB measurement, verification job metadata to InfluxDB
+    # tags and metric names and values to fields.
+
+    # Here we associate metrics (fields) to their corresponding
+    # packages (measurements)
+
+    fields = {}
+    for meas in data['measurements']:
+        influxdb_measurement = meas['metric'].split('.')[0]
+
+        if influxdb_measurement not in fields:
+            fields[influxdb_measurement] = []
+
+        if not math.isnan(meas['value']):
+            fields[influxdb_measurement].append("{}={}".format(meas['metric'],
+                                                               meas['value']))
+
+    timestamp = ""
+    if date_created:
+        timestamp = format_timestamp(date_created)
+
+    # add the squash job_id and the ci_dataset as metadata
+    data['meta']['squash_job_id'] = job_id
+
+    if 'ci_dataset' in data['meta']['env']:
+        data['meta']['ci_dataset'] = data['meta']['env']['ci_dataset']
+
+    # skip other job metadata when forming tags
+    del data['meta']['env']
+    del data['meta']['packages']
+
+    tags = []
+    for key, value in data['meta'].items():
+        # tag values cannot have blank spaces
+        if type(value) == str:
+            value = value.replace(" ", "_")
+            tags.append("{}={}".format(key, value))
+        else:
+            tags.append("{}={}".format(key, value))
+
+    for measurement in fields:
+        influxdb_line = format_line(measurement, tags, fields[measurement],
+                                    timestamp)
+
+        status_code, message = send_to_influxdb(influxdb_line)
+
+    return status_code, message

--- a/kubernetes/deployment-template.yaml
+++ b/kubernetes/deployment-template.yaml
@@ -56,6 +56,10 @@ spec:
             value: 'redis://localhost:6379'
           - name: S3_BUCKET
             value: {{ SQUASH_S3_BUCKET }}
+          - name: INFLUXDB_API_URL
+            value: {{ INFLUXDB_API_URL }}
+          - name: INFLUXDB_DATABASE
+            value: {{ INFLUXDB_DATABASE }}
           - name: AWS_ACCESS_KEY_ID
             valueFrom:
               secretKeyRef:
@@ -103,6 +107,10 @@ spec:
             value: 'redis://localhost:6379'
           - name: S3_BUCKET
             value: {{ SQUASH_S3_BUCKET }}
+          - name: INFLUXDB_API_URL
+            value: {{ INFLUXDB_API_URL }}
+          - name: INFLUXDB_DATABASE
+            value: {{ INFLUXDB_DATABASE }}
           - name: AWS_ACCESS_KEY_ID
             valueFrom:
               secretKeyRef:

--- a/kubernetes/replace.sh
+++ b/kubernetes/replace.sh
@@ -54,6 +54,16 @@ if [ "$INSTANCE_CONNECTION_NAME" == "" ]; then
     exit 1
 fi
 
+if [ "$INFLUXDB_API_URL" == "" ]; then
+    echo "INFLUXDB_API_URL not set."
+    exit 1
+fi
+
+if [ "$INFLUXDB_DATABASE" == "" ]; then
+    echo "INFLUXDB_DATABASE not set."
+    exit 1
+fi
+
 sed -e "
 s/{{ TAG }}/${TAG}/
 s/{{ SQUASH_API_HOST }}/${SQUASH_API_HOST}/
@@ -62,5 +72,7 @@ s/{{ SQUASH_DEFAULT_USER }}/${SQUASH_DEFAULT_USER}/
 s/{{ SQUASH_DEFAULT_PASSWORD }}/${SQUASH_DEFAULT_PASSWORD}/
 s/{{ SQUASH_ETL_MODE }}/\'${SQUASH_ETL_MODE}\'/
 s/{{ INSTANCE_CONNECTION_NAME }}/${INSTANCE_CONNECTION_NAME}/
+s|{{ INFLUXDB_API_URL }}|${INFLUXDB_API_URL}|
+s/{{ INFLUXDB_DATABASE }}/${INFLUXDB_DATABASE}/
 
 " $1 > $2

--- a/run.py
+++ b/run.py
@@ -32,10 +32,11 @@ app = create_app(profile)
 
 honey_api_key = os.environ.get('HONEY_API_KEY')
 
-beeline.init(writekey=honey_api_key, dataset="squash-rest-api",
-             service_name="squash")
-beeline.add_field('squash_api_profile', profile)
-HoneyMiddleware(app, db_events=True)
+if honey_api_key:
+    beeline.init(writekey=honey_api_key, dataset="squash-rest-api",
+                 service_name="squash")
+    beeline.add_field('squash_api_profile', profile)
+    HoneyMiddleware(app, db_events=True)
 
 
 @app.cli.command()


### PR DESCRIPTION
The `/job` resource uses the `save_job_to_influxdb()` method to invoke the `job_to_influxdb()` celery task. 

The transformation of a SQuaSH job to InfluxDB line maps each verification package to an InfluxDB measurement, job metadata to InfluxDB tags and metric names and values to fields.