### PR TITLE
[DM-16660] Deploy SQuaSH API to production and update InfluxDB with validate_drp results

### DIFF
--- a/app/tasks/influxdb.py
+++ b/app/tasks/influxdb.py
@@ -126,10 +126,13 @@ def job_to_influxdb(self, job_id, date_created, data):
         timestamp = format_timestamp(date_created)
 
     # add the squash job_id and the ci_dataset as metadata
-    data['meta']['squash_job_id'] = job_id
+    data['meta']['squash_id'] = job_id
 
     if 'ci_dataset' in data['meta']['env']:
         data['meta']['ci_dataset'] = data['meta']['env']['ci_dataset']
+
+    if 'ci_id' in data['meta']['env']:
+        data['meta']['ci_id'] = data['meta']['env']['ci_id']
 
     # skip other job metadata when forming tags
     del data['meta']['env']
@@ -137,12 +140,17 @@ def job_to_influxdb(self, job_id, date_created, data):
 
     tags = []
     for key, value in data['meta'].items():
-        # tag values cannot have blank spaces
+        # scape white space, comma and equal sign characters
+        # https://docs.influxdata.com/influxdb/v0.13/write_protocol
+        key = key.replace(" ", "\ ")
+        key = key.replace(",", "\,")
+        key = key.replace("=", "\=")
         if type(value) == str:
-            value = value.replace(" ", "_")
-            tags.append("{}={}".format(key, value))
-        else:
-            tags.append("{}={}".format(key, value))
+            value = value.replace(" ", "\ ")
+            value = value.replace(",", "\,")
+            value = value.replace("=", "\=")
+
+        tags.append("{}={}".format(key, value))
 
     for measurement in fields:
         influxdb_line = format_line(measurement, tags, fields[measurement],

--- a/app/tasks/influxdb.py
+++ b/app/tasks/influxdb.py
@@ -142,13 +142,13 @@ def job_to_influxdb(self, job_id, date_created, data):
     for key, value in data['meta'].items():
         # scape white space, comma and equal sign characters
         # https://docs.influxdata.com/influxdb/v0.13/write_protocol
-        key = key.replace(" ", "\ ")
-        key = key.replace(",", "\,")
-        key = key.replace("=", "\=")
+        key = key.replace(" ", "\ ") # noqa
+        key = key.replace(",", "\,") # noqa
+        key = key.replace("=", "\=") # noqa
         if type(value) == str:
-            value = value.replace(" ", "\ ")
-            value = value.replace(",", "\,")
-            value = value.replace("=", "\=")
+            value = value.replace(" ", "\ ") # noqa
+            value = value.replace(",", "\,") # noqa
+            value = value.replace("=", "\=") # noqa
 
         tags.append("{}={}".format(key, value))
 

--- a/examples/inlfuxdb.ipynb
+++ b/examples/inlfuxdb.ipynb
@@ -1,0 +1,278 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Sending SQuaSH data to InfluxDB\n",
+    "\n",
+    "In this notebook we reproduce what the InfluxDB Cellery task in the SQuaSH API does, and execute this code to synchronize the SQuaSH production data with an InfluxDB instance. See also [this notebook](https://github.com/lsst-sqre/influx-demo) for a quick introduction on InfluxDB concepts."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "SQUASH_API_URL = \"https://squash-restful-api.lsst.codes/\"\n",
+    "INFLUXDB_API_URL = \"https://influxdb-demo.lsst.codes\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We start by creating a new database. Note that if the database already exists nothing is done (the existing data is preserved), and an status code 200 (OK) is returned."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import requests\n",
+    "import json\n",
+    "\n",
+    "INFLUXDB_DATABASE = \"squash-prod\"\n",
+    "\n",
+    "params={'q': 'CREATE DATABASE \"{}\"'.format(INFLUXDB_DATABASE)}\n",
+    "r = requests.post(url=INFLUXDB_API_URL + \"/query\", params=params)\n",
+    "r.status_code"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The following cells will grab SQuaSH data and write it in the format used by InfluxDB (called [line protocol](https://docs.influxdata.com/influxdb/v1.6/write_protocols/line_protocol_tutorial/)):\n",
+    "\n",
+    "\n",
+    "```#<measurement>[,<tag_key>=<tag_value>[,<tag_key>=<tag_value>]] <field_key>=<field_value>[,<field_key>=<field_value>] [<timestamp>]```\n",
+    "\n",
+    "the important thing here is that an InfluxDB measurement is equivalent to a \"table\", tags are annotations that are used to query the data, and thus are indexed. Fields correspond to the actual values, and the timestamp acts like the \"primary key\" in InfluxDB.\n",
+    "\n",
+    "As you run this notebook you might follow the data ingestion using the [Data Explorer](https://chronograf-demo.lsst.codes/) tool in Chronograf."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import math\n",
+    "from pytz import UTC\n",
+    "from datetime import datetime\n",
+    "from dateutil.parser import parse"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def format_timestamp(date):\n",
+    "    \"\"\" Format timestamp as required by the InfluxDB line protocol.\n",
+    "\n",
+    "        Parameters\n",
+    "        ----------\n",
+    "        date: `<str>`\n",
+    "            Timestamp string\n",
+    "\n",
+    "        Returns\n",
+    "        -------\n",
+    "        timestamp: `<int>`\n",
+    "            Timestamp in nanosecond-precision Unix time.\n",
+    "            See https://docs.influxdata.com/influxdb/v1.6/write_protocols/\n",
+    "    \"\"\"\n",
+    "\n",
+    "    epoch = UTC.localize(datetime.utcfromtimestamp(0))\n",
+    "\n",
+    "    timestamp = int((parse(date) - epoch).total_seconds() * 1e9)\n",
+    "\n",
+    "    return timestamp\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def format_line(measurement, tags, fields, timestamp):\n",
+    "    \"\"\" Format an InfluxDB line.\n",
+    "\n",
+    "        Parameters\n",
+    "        ----------\n",
+    "        measurement: `<str>`\n",
+    "            Name of the InfluxDB measurement\n",
+    "        tags: `<list>`\n",
+    "            A list of valid InfluxDB tags\n",
+    "        fields: `<list>`\n",
+    "            A list of valid InfluxDB fields\n",
+    "        timestamp: `int`\n",
+    "            A timestamp as returned by `format_timestamp()`\n",
+    "\n",
+    "        Returns\n",
+    "        -------\n",
+    "        line: `<str>`\n",
+    "            An InfluxDB line as defined by the line protocol in\n",
+    "            https://docs.influxdata.com/influxdb/v1.6/write_protocols/\n",
+    "    \"\"\"\n",
+    "    line = \"{},{} {} {}\".format(measurement, \",\".join(tags), \",\".join(fields),\n",
+    "                                timestamp)\n",
+    "    return line\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def send_to_influxdb(influxdb_line):\n",
+    "    \"\"\" Send a line to an InfluxDB database. It assumes the database already\n",
+    "        exists.\n",
+    "\n",
+    "        Parameters\n",
+    "        ----------\n",
+    "        influxdb_line: `<str>`\n",
+    "            An InfluxDB line as defined by the line protocol in\n",
+    "            https://docs.influxdata.com/influxdb/v1.6/write_protocols/\n",
+    "\n",
+    "        status_code: `<int>`\n",
+    "            Status code from the InfluxDB HTTP API.\n",
+    "    \"\"\"\n",
+    "\n",
+    "    params = {'db': INFLUXDB_DATABASE}\n",
+    "    r = requests.post(url=INFLUXDB_API_URL + \"/write\", params=params,\n",
+    "                      data=influxdb_line)\n",
+    "\n",
+    "    return r.status_code, r.text\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "def job_to_influxdb(job_id, data):\n",
+    "    \"\"\" Unpack a SQuaSH job and send to InfluxDB\n",
+    "\n",
+    "        Parameters\n",
+    "        ----------\n",
+    "        data: `<dict>`\n",
+    "            A dictionary containing the job data\n",
+    "\n",
+    "        Returns\n",
+    "        -------\n",
+    "        status_code: `<int>`\n",
+    "             204:\n",
+    "               The request was processed successfully\n",
+    "             400:\n",
+    "               Malformed syntax or bad query\n",
+    "\n",
+    "        Note\n",
+    "        ----\n",
+    "        A lsst.verify measurement and an InfluxDB measurement are different\n",
+    "        things. See e.g.:\n",
+    "        https://docs.influxdata.com/influxdb/v1.6/concepts/key_concepts/\n",
+    "    \"\"\"\n",
+    "\n",
+    "    # The datamodel for a SQuaSH job in InfluxDB maps each verification package\n",
+    "    # to an InfluxDB measurement, verification job metadata to InfluxDB\n",
+    "    # tags and metric names and values to fields.\n",
+    "\n",
+    "    # Here we associate metrics (fields) to their corresponding\n",
+    "    # packages (measurements)\n",
+    "\n",
+    "    fields = {}\n",
+    "    for meas in data['measurements']:\n",
+    "        influxdb_measurement = meas['metric'].split('.')[0]\n",
+    "\n",
+    "        if influxdb_measurement not in fields:\n",
+    "            fields[influxdb_measurement] = []\n",
+    "\n",
+    "        if not math.isnan(meas['value']):\n",
+    "            fields[influxdb_measurement].append(\"{}={}\".format(meas['metric'],\n",
+    "                                                               meas['value']))\n",
+    "\n",
+    "    timestamp = format_timestamp(data['date_created'])\n",
+    "\n",
+    "    # add the squash job_id and the ci_dataset as metadata\n",
+    "    data['meta']['squash_job_id'] = job_id\n",
+    "\n",
+    "    if 'ci_dataset' in data['meta']['env']:\n",
+    "        data['meta']['ci_dataset'] = data['meta']['env']['ci_dataset']\n",
+    "\n",
+    "    # skip other job metadata when forming tags\n",
+    "    del data['meta']['env']\n",
+    "    del data['meta']['packages']\n",
+    "\n",
+    "    tags = []\n",
+    "    for key, value in data['meta'].items():\n",
+    "        # tag values cannot have blank spaces\n",
+    "        if type(value) == str:\n",
+    "            value = value.replace(\" \", \"_\")\n",
+    "            tags.append(\"{}={}\".format(key, value))\n",
+    "        else:\n",
+    "            tags.append(\"{}={}\".format(key, value))\n",
+    "\n",
+    "    for measurement in fields:\n",
+    "        influxdb_line = format_line(measurement, tags, fields[measurement],\n",
+    "                                    timestamp)\n",
+    "\n",
+    "        status_code, message = send_to_influxdb(influxdb_line)\n",
+    "        if status_code != 204:\n",
+    "            print(message)\n",
+    "\n",
+    "    return "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "jobs = requests.get(SQUASH_API_URL + \"/jobs\").json()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for job_id in jobs['ids']:\n",
+    "\n",
+    "    data = requests.get(SQUASH_API_URL + \"/job/{}\".format(job_id)).json()\n",
+    "\n",
+    "    # Skip datasets we don't want \n",
+    "    if data['ci_dataset'] == 'unknown' or data['ci_dataset'] == 'decam':\n",
+    "        continue\n",
+    "\n",
+    "    print('Sending line for job {}...'.format(job_id))\n",
+    "    \n",
+    "    job_to_influxdb(job_id, data)\n",
+    "    "
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/examples/inlfuxdb.ipynb
+++ b/examples/inlfuxdb.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Sending SQuaSH data to InfluxDB\n",
     "\n",
-    "In this notebook we reproduce what the InfluxDB Cellery task in the SQuaSH API does, and execute this code to synchronize the SQuaSH production data with an InfluxDB instance. See also [this notebook](https://github.com/lsst-sqre/influx-demo) for a quick introduction on InfluxDB concepts."
+    "This notebook reproduces what the SQuaSH API InfluxDB Celery does, and can be used to \"manually\" synchronize the SQuaSH production data with an InfluxDB instance. See also [this notebook](https://github.com/lsst-sqre/influx-demo) for a quick introduction on InfluxDB concepts."
    ]
   },
   {
@@ -35,7 +35,7 @@
     "import requests\n",
     "import json\n",
     "\n",
-    "INFLUXDB_DATABASE = \"squash-prod\"\n",
+    "INFLUXDB_DATABASE = \"test\"\n",
     "\n",
     "params={'q': 'CREATE DATABASE \"{}\"'.format(INFLUXDB_DATABASE)}\n",
     "r = requests.post(url=INFLUXDB_API_URL + \"/query\", params=params)\n",
@@ -157,6 +157,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This function was adapted from `tasks/influxdb.py` "
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -207,10 +214,13 @@
     "    timestamp = format_timestamp(data['date_created'])\n",
     "\n",
     "    # add the squash job_id and the ci_dataset as metadata\n",
-    "    data['meta']['squash_job_id'] = job_id\n",
+    "    data['meta']['squash_id'] = job_id\n",
     "\n",
-    "    if 'ci_dataset' in data['meta']['env']:\n",
-    "        data['meta']['ci_dataset'] = data['meta']['env']['ci_dataset']\n",
+    "    if 'ci_dataset' in data:\n",
+    "        data['meta']['ci_dataset'] = data['ci_dataset']\n",
+    "    \n",
+    "    if 'ci_id' in data['meta']['env']:\n",
+    "        data['meta']['ci_id'] = data['meta']['env']['ci_id']\n",
     "\n",
     "    # skip other job metadata when forming tags\n",
     "    del data['meta']['env']\n",
@@ -218,12 +228,18 @@
     "\n",
     "    tags = []\n",
     "    for key, value in data['meta'].items():\n",
-    "        # tag values cannot have blank spaces\n",
+    "    \n",
+    "        # scape white space, comma and equal sign characters\n",
+    "        # https://docs.influxdata.com/influxdb/v0.13/write_protocols/write_syntax/#escaping-characters\n",
+    "        key = key.replace(\" \", \"\\ \")\n",
+    "        key = key.replace(\",\", \"\\,\" )\n",
+    "        key = key.replace(\"=\", \"\\=\")\n",
     "        if type(value) == str:\n",
-    "            value = value.replace(\" \", \"_\")\n",
-    "            tags.append(\"{}={}\".format(key, value))\n",
-    "        else:\n",
-    "            tags.append(\"{}={}\".format(key, value))\n",
+    "            value = value.replace(\" \", \"\\ \")\n",
+    "            value = value.replace(\",\", \"\\,\" )\n",
+    "            value = value.replace(\"=\", \"\\=\")\n",
+    "        \n",
+    "        tags.append(\"{}={}\".format(key, value))\n",
     "\n",
     "    for measurement in fields:\n",
     "        influxdb_line = format_line(measurement, tags, fields[measurement],\n",
@@ -271,6 +287,18 @@
    "display_name": "Python 3",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.1"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Added notebook reproduces what the SQuaSH API InfluxDB Celery does, and can be used to "manually" synchronize the SQuaSH production data with an InfluxDB instance.